### PR TITLE
Add write back support for unmount option and copy to support for mount option

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ repository = "https://github.com/PauMAVA/cargo-ramdisk"
 
 [dependencies]
 structopt = "0.3"
-sys-mount = "1.3.0"
+sys-mount = "2"
 nanoid = "0.4.0"
-
 carlog = "0.1.0"

--- a/src/config.rs
+++ b/src/config.rs
@@ -52,12 +52,17 @@ pub struct UnmountConfig {
     /// The path to the target folder where compilation output is written
     #[structopt(default_value = "target", short, long)]
     pub target: PathBuf,
+
+    /// Copy back the contents of the ramdisk to the target folder
+    #[structopt(short, long)]
+    pub copy_back: bool,
 }
 
 impl From<&RemountConfig> for UnmountConfig {
     fn from(config: &RemountConfig) -> Self {
         Self {
             target: config.target.clone(),
+            copy_back: false,
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -22,12 +22,17 @@ pub struct MountConfig {
     /// The path to the target folder where compilation output is written
     #[structopt(default_value = "./target", short, long)]
     pub target: PathBuf,
+
+    /// Copy the contents of the target folder to the ramdisk
+    #[structopt(short, long)]
+    pub copy_to: bool,
 }
 
 impl From<CargoRamdiskConfig> for MountConfig {
     fn from(conf: CargoRamdiskConfig) -> Self {
         Self {
             target: conf.target,
+            copy_to: false,
         }
     }
 }
@@ -36,6 +41,7 @@ impl From<&RemountConfig> for MountConfig {
     fn from(config: &RemountConfig) -> Self {
         Self {
             target: config.target.clone(),
+            copy_to: false,
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -295,7 +295,10 @@ mod test {
         std::fs::write(target.join("test.txt"), "test").expect("Failed to create test file");
 
         // Get the original timestamp
-        let original_timestamp = std::fs::metadata(target.join("test.txt")).unwrap().modified().unwrap();
+        let original_timestamp = std::fs::metadata(target.join("test.txt"))
+            .unwrap()
+            .modified()
+            .unwrap();
 
         // Mount with copy_to
         let mntcfg = MountConfig {
@@ -311,26 +314,36 @@ mod test {
         assert!(link.starts_with(BASE_RAMDISK_FOLDER));
 
         // Check that the timestamp is the same
-        let copied_timestamp = std::fs::metadata(link.join("test.txt")).unwrap().modified().unwrap();
+        let copied_timestamp = std::fs::metadata(link.join("test.txt"))
+            .unwrap()
+            .modified()
+            .unwrap();
         assert_eq!(original_timestamp, copied_timestamp);
 
         // Modify the test file
         std::thread::sleep(std::time::Duration::from_millis(10)); // Sleep to make sure the timestamp changes
         std::fs::write(link.join("test.txt"), "test2").expect("Failed to write to test file");
 
-        let modified_timestamp = std::fs::metadata(link.join("test.txt")).unwrap().modified().unwrap();
+        let modified_timestamp = std::fs::metadata(link.join("test.txt"))
+            .unwrap()
+            .modified()
+            .unwrap();
         assert_ne!(original_timestamp, modified_timestamp);
 
         // Unmount with copy_back
         unmount(UnmountConfig {
             target: target.clone(),
             copy_back: true,
-        }).expect("Failed to unmount test tmpfs");
+        })
+        .expect("Failed to unmount test tmpfs");
 
         assert!(!link.exists());
         assert!(target.exists());
 
-        let copied_back_timestamp = std::fs::metadata(target.join("test.txt")).unwrap().modified().unwrap();
+        let copied_back_timestamp = std::fs::metadata(target.join("test.txt"))
+            .unwrap()
+            .modified()
+            .unwrap();
         assert_eq!(modified_timestamp, copied_back_timestamp);
 
         // Cleanup


### PR DESCRIPTION
Add a `-c, --copy-back` option for the unmount operation. 

Achieved by using `cp` instead of `std::fs::copy`, because cargo uses the file timestamps to determine if a file has changed.