### PR TITLE
Removed loopdevice feature from sys-mount

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,6 @@ repository = "https://github.com/PauMAVA/cargo-ramdisk"
 
 [dependencies]
 structopt = "0.3"
-sys-mount = "2"
+sys-mount = {version = "2", default-features = false}
 nanoid = "0.4.0"
 carlog = "0.1.0"


### PR DESCRIPTION
The loopdev crate currently failes to compile on some platforms, see https://github.com/mdaffin/loopdev/issues/65.
Because it failes to compile and the sys-mount crate lists it as a dependency, this crate failes to compile as well.

Since the loopdev feature of sys-mount is not necessary for this crate, this pull request disables the loop feature of sys-mount that is responsible for loopdev crate.