### PR TITLE
Remove unused sys-mount crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,5 @@ repository = "https://github.com/PauMAVA/cargo-ramdisk"
 
 [dependencies]
 structopt = "0.3"
-sys-mount = {version = "2", default-features = false}
 nanoid = "0.4.0"
 carlog = "0.1.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,5 @@
 extern crate nanoid;
 extern crate structopt;
-extern crate sys_mount;
 #[macro_use]
 extern crate carlog;
 


### PR DESCRIPTION
`sys-mount` makes error on MacOS, but it doesn't used in this crate.